### PR TITLE
Use node image for base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
-FROM ubuntu
+FROM node:8.9.3-alpine
 
-RUN apt-get update && apt-get install -yq nodejs npm
-
-RUN mkdir /app
 WORKDIR /app
 
 ADD package.json /app/
@@ -12,5 +9,4 @@ ADD server.js /app/
 ADD mime-types.json /app/
 
 EXPOSE 8081
-USER nobody
-CMD nodejs server.js
+CMD node server.js


### PR DESCRIPTION
## WHAT

Use `node:8.9.3-alpine` as the base docker image of camo image.