### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+Unreleased
+=====
+
+3.0.0
+=====
+
+* Fix certificate error (upgrade node version from v8 to v16) [5](https://github.com/increments/camo/pull/5)
+
+2.3.1
+=====
+
+* Support for Let's Encrypt root certificate changes (ISRG Root X1) [4](https://github.com/increments/camo/pull/4)
+
 2.3.0
 =====
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "camo",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "camo",
-      "version": "2.3.0",
+      "version": "3.0.0",
       "devDependencies": {
         "coffee-script": "^1.12.6"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camo",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "dependencies": {},
   "engines": {
     "node": "^16"


### PR DESCRIPTION
## What

- Release v3.0.0
    - [#5](https://github.com/increments/camo/pull/5): Fix certificate error (upgrade node version from v8 to v16) by @mziyut 

