### PR TITLE
Support node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.20.2
+FROM node:18.17.1
 
 RUN apt-get update && \
     apt-get -y clean && \

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "coffee-script": "^1.12.6"
       },
       "engines": {
-        "node": "^16"
+        "node": "^16 || ^17 || ^18"
       }
     },
     "node_modules/coffee-script": {


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

This PR updates node 17 and 18. Besides, update docker base image to use [18.17.1](https://hub.docker.com/layers/library/node/18.17.1/images/sha256-91e37377b960d0b15d3c15d15321084163bc8d950e14f77bbc84ab23cf3d6da7?context=explore).

## operation check

I've tested the docker image in our infra. (https://github.com/increments/camo-ecspresso/issues/4)
