### PR TITLE
Release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Unreleased
 
 <!-- Add descriptions of changes here -->
 
+3.2.0
+=====
+
 * Add support for Node v20 and drop support for Node v17 or before [22](https://github.com/increments/camo/pull/22)
 
 3.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "camo",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "camo",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "devDependencies": {
         "coffee-script": "^1.12.6"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camo",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "dependencies": {},
   "engines": {
     "node": "^18 || ^20"


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
## What

- Release v3.2.0
    - Add support for Node v20 and drop support for Node v17 or before [22](https://github.com/increments/camo/pull/22)